### PR TITLE
fix: prism highlight parser error

### DIFF
--- a/src/@types/Core.d.ts
+++ b/src/@types/Core.d.ts
@@ -8,7 +8,7 @@ declare global {
   interface CoreRequest {
     requestId: string;
     query: string;
-    variables: AnyObject;
+    variables?: AnyObject;
   }
 
   interface CoreRequestMetaData {

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -29,7 +29,7 @@ function CodeEditor({
         'graphql'
       ),
       variables: Prism.highlight(
-        JSON.stringify(selectedRequest.variables),
+        JSON.stringify(selectedRequest.variables || {}),
         Prism.languages.json,
         'json'
       )


### PR DESCRIPTION
some queries don't have variables, it was arriving undefined at the `prims.highlight` function in the `CodeEditor` component, throwing an error because the code wasn't treated for that.

I've changed the type of the variables to be undefined or any object now, so we can safely coding always knowing that variables can be undefined.

👊