### PR TITLE
feat: add error status code Closes: #10

### DIFF
--- a/src/@types/Core.d.ts
+++ b/src/@types/Core.d.ts
@@ -1,7 +1,7 @@
 import { MachineConfig } from 'xstate';
 
 declare global {
-  type StatusCode = number | 'loading' | 'canceled';
+  type StatusCode = number | 'loading' | 'canceled' | 'error';
   type Operation = 'query' | 'mutation';
   type CoreRequestMetaDataById = { [key: string]: CoreRequestMetaData };
 
@@ -38,10 +38,11 @@ declare global {
     };
   }
 
-  interface ON_REQUEST_CANCELED {
-    type: 'ON_REQUEST_CANCELED';
+  interface ON_REQUEST_ERROR {
+    type: 'ON_REQUEST_ERROR';
     payload: {
       requestId: string;
+      statusCode: StatusCode;
     };
   }
 
@@ -63,7 +64,7 @@ declare global {
     | ON_REQUEST_COMPLETE
     | ON_BEFORE_SEND_HEADERS
     | OPEN_REQUEST_DETAILS
-    | ON_REQUEST_CANCELED;
+    | ON_REQUEST_ERROR;
 
   interface CoreSchema {
     states: {

--- a/src/core/actions.ts
+++ b/src/core/actions.ts
@@ -50,9 +50,9 @@ export const setRequestAsComplete = assign<CoreContext, CoreEvents>({
   }
 });
 
-export const setRequestAsCanceled = assign<CoreContext, CoreEvents>({
+export const setRequestStatusCode = assign<CoreContext, CoreEvents>({
   resquestsMetaDataById: (context, event) => {
-    const { requestId } = (event as ON_REQUEST_CANCELED).payload;
+    const { requestId, statusCode } = (event as ON_REQUEST_ERROR).payload;
 
     if (!requestExist(context, requestId)) return context.resquestsMetaDataById;
 
@@ -62,7 +62,7 @@ export const setRequestAsCanceled = assign<CoreContext, CoreEvents>({
       request =>
         immutable
           .wrap(request)
-          .set('statusCode', 'canceled')
+          .set('statusCode', statusCode)
           .update('timeStamp', timeStamp => ({
             ...timeStamp,
             end: new Date().getTime()

--- a/src/core/machine.tsx
+++ b/src/core/machine.tsx
@@ -30,9 +30,9 @@ export default Machine(
             target: '',
             actions: 'setRequestHeaders'
           },
-          ON_REQUEST_CANCELED: {
+          ON_REQUEST_ERROR: {
             target: '',
-            actions: 'setRequestAsCanceled'
+            actions: 'setRequestStatusCode'
           },
           OPEN_REQUEST_DETAILS: {
             actions: ['setSelectedRequest'],

--- a/src/core/services.ts
+++ b/src/core/services.ts
@@ -5,7 +5,7 @@ export const registerChromeEvents = () => (send: Sender<CoreEvents>) => {
   if (process.env.NODE_ENV !== 'development') {
     //@ts-ignore
     chrome.webRequest.onBeforeRequest.addListener(
-      function(details: any) {
+      function (details: any) {
         if (details.requestBody.raw[0]) {
           const queryDetails = JSON.parse(
             decodeURIComponent(
@@ -34,7 +34,7 @@ export const registerChromeEvents = () => (send: Sender<CoreEvents>) => {
 
     //@ts-ignore
     chrome.webRequest.onCompleted.addListener(
-      function(details: any) {
+      function (details: any) {
         send({
           type: 'ON_REQUEST_COMPLETE',
           payload: {
@@ -48,13 +48,12 @@ export const registerChromeEvents = () => (send: Sender<CoreEvents>) => {
 
     //@ts-ignore
     chrome.webRequest.onErrorOccurred.addListener(
-      function(details: any) {
-        if (details.error !== canceled_error) return;
-
+      function (details: any) {
         send({
-          type: 'ON_REQUEST_CANCELED',
+          type: 'ON_REQUEST_ERROR',
           payload: {
-            requestId: details.requestId
+            requestId: details.requestId,
+            statusCode: details.error === canceled_error ? 'canceled' : 'error'
           }
         });
       },
@@ -63,7 +62,7 @@ export const registerChromeEvents = () => (send: Sender<CoreEvents>) => {
 
     //@ts-ignore
     chrome.webRequest.onBeforeSendHeaders.addListener(
-      function(details: any) {
+      function (details: any) {
         send({
           type: 'ON_BEFORE_SEND_HEADERS',
           payload: {


### PR DESCRIPTION
introducing error as `statusCode` and treat the event as a just any error instead of only as canceled.

`error` = any fetch error different than HTTP errors or canceled, this happens especially when the server didn't answer.

👊 