### PR TITLE
Add active style to the selected request

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ function App() {
             }
             requests={requests}
             resquestsMetaDataById={resquestsMetaDataById}
+            selectedRequest={selectedRequest}
           />
         }
         Right={

--- a/src/components/Table.module.css
+++ b/src/components/Table.module.css
@@ -1,5 +1,5 @@
 @value colors: "../styles/colors.module.css";
-@value table-hover, gray from colors;
+@value table-hover, gray, light-gray from colors;
 
 .table {
   width: 100%;
@@ -33,6 +33,10 @@ td:nth-child(2) {
 
 .table tr:hover {
   background: table-hover;
+}
+
+.table tr.isActive {
+  background: light-gray;
 }
 
 .table tbody::before {

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,19 +1,23 @@
 import React, { useCallback } from 'react';
+import ClassNames from 'classnames';
 
 import Status from './Status';
 import RequestName from './RequestName';
 
 import styles from './Table.module.css';
+import { compareRequests } from './Table.utils';
 
 interface TableProps {
   requests: CoreRequest[];
   resquestsMetaDataById: CoreRequestMetaDataById;
+  selectedRequest?: CoreRequest;
   onRequestSelected: (request: CoreRequest) => void;
 }
 
 function Table({
   requests,
   resquestsMetaDataById,
+  selectedRequest,
   onRequestSelected
 }: TableProps) {
   const handleOnRequestSelected = useCallback(
@@ -45,6 +49,12 @@ function Table({
             <tr
               key={request.requestId}
               onClick={handleOnRequestSelected(request)}
+              className={ClassNames({
+                [styles.isActive]: (
+                  selectedRequest &&
+                  compareRequests(request, selectedRequest)
+                )
+              })}
             >
               <td>
                 <RequestName queryName={queryName} operation={operation} />

--- a/src/components/Table.utils.ts
+++ b/src/components/Table.utils.ts
@@ -1,0 +1,3 @@
+export const compareRequests = (request: CoreRequest, anotherRequest: CoreRequest) => (
+  request.requestId === anotherRequest.requestId
+)


### PR DESCRIPTION
Closes #7 

Screenshot, with an active item (darkest line) and hovered one (lightest line).

![Screenshot_2020-04-03_15-36-40](https://user-images.githubusercontent.com/11931916/78394156-7a58cf80-75c1-11ea-817e-ab9d98da56c4.png)

Maybe the color contrast between the line's background and the status code's one (at least the green color) might be bad for some users - I'm not an expert. What do you think? Any suggestions? :art: 