### PR TITLE
Fix Editor's top action's position

### DIFF
--- a/src/components/CodeEditor.module.css
+++ b/src/components/CodeEditor.module.css
@@ -15,9 +15,9 @@
 }
 
 .copy {
-  position: fixed;
-  top: 55px;
-  right: 55px;
+  position: absolute;
+  top: 8px;
+  right: 8px;
   padding: 10px;
   border-radius: 10px;
   background-color: white;


### PR DESCRIPTION
Since we introduced Header component, Editor's "top action"'s position has been broken. Making it `absolute` positioned rather than `fixed` was enough, considering Editor's root element has a `relative` position.