### PR TITLE
fix: EditorActions line-height and settings toggle

### DIFF
--- a/src/core/components/Settings.tsx
+++ b/src/core/components/Settings.tsx
@@ -28,9 +28,9 @@ function Settings({ send, current }: SettingsProps) {
     active: active,
   });
 
-  const handleOnOpen = useCallback(() => {
-    setModalStatus(ModalStatus.open);
-  }, []);
+  const handleOnClick = useCallback(() => {
+    setModalStatus(active ? ModalStatus.close : ModalStatus.open);
+  }, [active]);
 
   useOnOutsideClick(rootRef, () => {
     if (!active) return;
@@ -47,7 +47,7 @@ function Settings({ send, current }: SettingsProps) {
 
   return (
     <div ref={rootRef} className={styles.settings}>
-      <div className={iconBoxClassName} onClick={handleOnOpen}>
+      <div className={iconBoxClassName} onClick={handleOnClick}>
         {!active && !current.context.settings.urls.length && (
           <div className={styles.alert} />
         )}

--- a/src/domains/editor/components/EditorActions.module.css
+++ b/src/domains/editor/components/EditorActions.module.css
@@ -22,6 +22,7 @@
   border-radius: 10px;
   background-color: white;
   cursor: pointer;
+  line-height: 1;
 }
 
 .action svg {


### PR DESCRIPTION
Hi @dielduarte,

I found two small issues.

EditorActions with 1.5 of line-height is rectangular.
![image](https://user-images.githubusercontent.com/7620947/81482969-1acd8f80-9211-11ea-89ef-6c4f5c843f4b.png)

With 1.0, it gets a nice square format.
![image](https://user-images.githubusercontent.com/7620947/81482964-0e493700-9211-11ea-89ef-da4af1800f23.png)

Ok, maybe it is a TOC mine! :smile: 

The second one is the toggle effect of the settings button. When it opens, it does not close with a second click. 

Thank you for the plugin, it is a nice and helpful tool!