### PR TITLE
fix(Settings): set urls on toggle settings by clicking on the icon

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "useTabs": false,
+  "tabWidth": 2,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 120
+}

--- a/src/core/components/Settings.tsx
+++ b/src/core/components/Settings.tsx
@@ -7,65 +7,66 @@ import styles from './Settings.module.css';
 import useOnOutsideClick from '../../hooks/useOnOutsideClick';
 
 interface SettingsProps {
-  send: Sender<CoreEvents>;
-  current: State<CoreContext, CoreEvents>;
+	send: Sender<CoreEvents>;
+	current: State<CoreContext, CoreEvents>;
 }
 
 enum ModalStatus {
-  open,
-  close,
+	open,
+	close,
 }
 
 function Settings({ send, current }: SettingsProps) {
-  const [modalStatus, setModalStatus] = useState<ModalStatus>(
-    ModalStatus.close
-  );
-  const rootRef = useRef(null);
-  const textAreaRef = useRef<HTMLTextAreaElement>(null);
-  const active = modalStatus === ModalStatus.open;
-  const iconBoxClassName = classNames({
-    [styles.iconBox]: true,
-    active: active,
-  });
+	const [modalStatus, setModalStatus] = useState<ModalStatus>(ModalStatus.close);
+	const rootRef = useRef(null);
+	const textAreaRef = useRef<HTMLTextAreaElement>(null);
+	const active = modalStatus === ModalStatus.open;
+	const iconBoxClassName = classNames({
+		[styles.iconBox]: true,
+		active: active,
+	});
 
-  const handleOnClick = useCallback(() => {
-    setModalStatus(active ? ModalStatus.close : ModalStatus.open);
-  }, [active]);
+	const setUrls = useCallback(() => {
+		send({
+			type: 'SET_URLS',
+			payload: {
+				urls: textAreaRef.current ? textAreaRef.current.value : '',
+			},
+		});
+	}, [send]);
 
-  useOnOutsideClick(rootRef, () => {
-    if (!active) return;
+	const toggleSettingMenu = useCallback(() => {
+		setModalStatus(active ? ModalStatus.close : ModalStatus.open);
+		setUrls();
+	}, [active, setUrls]);
 
-    send({
-      type: 'SET_URLS',
-      payload: {
-        urls: textAreaRef.current ? textAreaRef.current.value : '',
-      },
-    });
+	useOnOutsideClick(rootRef, () => {
+		if (!active) return;
 
-    setModalStatus(ModalStatus.close);
-  });
+		setUrls();
 
-  return (
-    <div ref={rootRef} className={styles.settings}>
-      <div className={iconBoxClassName} onClick={handleOnClick}>
-        {!active && !current.context.settings.urls.length && (
-          <div className={styles.alert} />
-        )}
-        <RequestIcon />
-      </div>
-      {active && (
-        <div className={styles.inputContainer}>
-          <h3>separated by comma add URLs to start watching</h3>
-          <textarea
-            defaultValue={current.context.settings.urls.join(', ')}
-            ref={textAreaRef}
-            className={styles.textArea}
-            placeholder="https://myapi.rocks/graphql, https://otherapi.com/graphql"
-          />
-        </div>
-      )}
-    </div>
-  );
+		setModalStatus(ModalStatus.close);
+	});
+
+	return (
+		<div ref={rootRef} className={styles.settings}>
+			<div className={iconBoxClassName} onClick={toggleSettingMenu}>
+				{!active && !current.context.settings.urls.length && <div className={styles.alert} />}
+				<RequestIcon />
+			</div>
+			{active && (
+				<div className={styles.inputContainer}>
+					<h3>separated by comma add URLs to start watching</h3>
+					<textarea
+						defaultValue={current.context.settings.urls.join(', ')}
+						ref={textAreaRef}
+						className={styles.textArea}
+						placeholder='https://myapi.rocks/graphql, https://otherapi.com/graphql'
+					/>
+				</div>
+			)}
+		</div>
+	);
 }
 
 export default Settings;

--- a/src/core/components/Settings.tsx
+++ b/src/core/components/Settings.tsx
@@ -7,64 +7,64 @@ import styles from './Settings.module.css';
 import useOnOutsideClick from '../../hooks/useOnOutsideClick';
 
 interface SettingsProps {
-	send: Sender<CoreEvents>;
-	current: State<CoreContext, CoreEvents>;
+  send: Sender<CoreEvents>;
+  current: State<CoreContext, CoreEvents>;
 }
 
 enum ModalStatus {
-	open,
-	close,
+  open,
+  close,
 }
 
 function Settings({ send, current }: SettingsProps) {
-	const [modalStatus, setModalStatus] = useState<ModalStatus>(ModalStatus.close);
-	const rootRef = useRef(null);
-	const textAreaRef = useRef<HTMLTextAreaElement>(null);
-	const active = modalStatus === ModalStatus.open;
-	const iconBoxClassName = classNames({
-		[styles.iconBox]: true,
-		active: active,
-	});
+  const [modalStatus, setModalStatus] = useState<ModalStatus>(ModalStatus.close);
+  const rootRef = useRef(null);
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+  const active = modalStatus === ModalStatus.open;
+  const iconBoxClassName = classNames({
+    [styles.iconBox]: true,
+    active: active,
+  });
 
-	const setUrls = () => {
-		send({
-			type: 'SET_URLS',
-			payload: {
-				urls: textAreaRef.current ? textAreaRef.current.value : '',
-			},
-		});
-	};
+  const setUrls = () => {
+    send({
+      type: 'SET_URLS',
+      payload: {
+        urls: textAreaRef.current ? textAreaRef.current.value : '',
+      },
+    });
+  };
 
-	const toggleSettingMenu = () => {
-		setModalStatus(active ? ModalStatus.close : ModalStatus.open);
-		setUrls();
-	};
+  const toggleSettingMenu = () => {
+    setModalStatus(active ? ModalStatus.close : ModalStatus.open);
+    setUrls();
+  };
 
-	useOnOutsideClick(rootRef, () => {
-		if (!active) return;
-		setUrls();
-		setModalStatus(ModalStatus.close);
-	});
+  useOnOutsideClick(rootRef, () => {
+    if (!active) return;
+    setUrls();
+    setModalStatus(ModalStatus.close);
+  });
 
-	return (
-		<div ref={rootRef} className={styles.settings}>
-			<div className={iconBoxClassName} onClick={toggleSettingMenu}>
-				{!active && !current.context.settings.urls.length && <div className={styles.alert} />}
-				<RequestIcon />
-			</div>
-			{active && (
-				<div className={styles.inputContainer}>
-					<h3>separated by comma add URLs to start watching</h3>
-					<textarea
-						defaultValue={current.context.settings.urls.join(', ')}
-						ref={textAreaRef}
-						className={styles.textArea}
-						placeholder='https://myapi.rocks/graphql, https://otherapi.com/graphql'
-					/>
-				</div>
-			)}
-		</div>
-	);
+  return (
+    <div ref={rootRef} className={styles.settings}>
+      <div className={iconBoxClassName} onClick={toggleSettingMenu}>
+        {!active && !current.context.settings.urls.length && <div className={styles.alert} />}
+        <RequestIcon />
+      </div>
+      {active && (
+        <div className={styles.inputContainer}>
+          <h3>separated by comma add URLs to start watching</h3>
+          <textarea
+            defaultValue={current.context.settings.urls.join(', ')}
+            ref={textAreaRef}
+            className={styles.textArea}
+            placeholder="https://myapi.rocks/graphql, https://otherapi.com/graphql"
+          />
+        </div>
+      )}
+    </div>
+  );
 }
 
 export default Settings;

--- a/src/core/components/Settings.tsx
+++ b/src/core/components/Settings.tsx
@@ -26,19 +26,19 @@ function Settings({ send, current }: SettingsProps) {
 		active: active,
 	});
 
-	const setUrls = useCallback(() => {
+	const setUrls = () => {
 		send({
 			type: 'SET_URLS',
 			payload: {
 				urls: textAreaRef.current ? textAreaRef.current.value : '',
 			},
 		});
-	}, [send]);
+	};
 
-	const toggleSettingMenu = useCallback(() => {
+	const toggleSettingMenu = () => {
 		setModalStatus(active ? ModalStatus.close : ModalStatus.open);
 		setUrls();
-	}, [active, setUrls]);
+	};
 
 	useOnOutsideClick(rootRef, () => {
 		if (!active) return;

--- a/src/core/components/Settings.tsx
+++ b/src/core/components/Settings.tsx
@@ -42,9 +42,7 @@ function Settings({ send, current }: SettingsProps) {
 
 	useOnOutsideClick(rootRef, () => {
 		if (!active) return;
-
 		setUrls();
-
 		setModalStatus(ModalStatus.close);
 	});
 


### PR DESCRIPTION
# Scope 

Currently, if we close the settings modal by clicking in the icon after providing the URLs they are not being saved. This PR fixes that by dispatching the action on the toggle handler. 

To achieve that had to put the action in a separated function 

```typescript
    const setUrls = () => {
        send({
            type: 'SET_URLS',
                payload: {
		    urls: textAreaRef.current ? textAreaRef.current.value : '',
		},
         });
    };
```

Also renamed `handleOnClick` to a more meaningful name: `toggleSettingMenu` and remove it from `useCalback` since there's no benefit there as the dep will change and at each render anyway. 